### PR TITLE
Recommend Observable Networks ona-service

### DIFF
--- a/ossec-hids-local-2.8.1/debian/control
+++ b/ossec-hids-local-2.8.1/debian/control
@@ -10,6 +10,7 @@ Package: ossec-hids-local
 Architecture: any
 Pre-Depends: debconf (>= 0.2.17) | debconf-2.0
 Conflicts: ossec-hids-server, ossec-hids-agent
+Recommends: ona-service
 Description: Open Source Security, Host-Based Intrusion Detection System
  It performs log analysis, integrity checking, Windows registry monitoring,
  rootkit detection, real-time alerting and active response.

--- a/ossec-hids-local-2.8.1/debian/ossec-hids-local.postinst
+++ b/ossec-hids-local-2.8.1/debian/ossec-hids-local.postinst
@@ -48,6 +48,12 @@ case "$1" in
 	then
 			useradd -d ${DIR} -s ${OSMYSHELL} -g ${GROUP} ${USER_REM}
 	fi
+    # If the ona-service package (recommended) is installed, add the obsrvbl_ona
+    # user to the ossec group so it can read alert logs.
+	if getent passwd | grep -q "^obsrvbl_ona:"
+	then
+			usermod -a -G ${GROUP} obsrvbl_ona
+	fi
 
 # Default for all directories
 chmod 550 ${DIR}
@@ -170,7 +176,6 @@ chmod 550 ${DIR}/bin/*
 # config file
 chown root:${GROUP} ${DIR}/etc/ossec.conf
 chmod 440 ${DIR}/etc/ossec.conf
-
 
 ###
 # debconf now


### PR DESCRIPTION
This PR changes the post-install script for the .deb package add the `obsrvbl_ona` user from the Observable Networks ona-service package to the `ossec` group. This allows that user to read OSSEC alerts.

I've also added the ona-service package to the `Recommends` list for this distribution of the OSSEC package.
