### PR TITLE
Use obsrvbl Docker image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-image: bbayles/centos-packager:latest
+image: obsrvbl/docker-images:ossec-centos-6
 
 env:
   - PREFIX=/opt/obsrvbl/ossec


### PR DESCRIPTION
Switches to the [https://hub.docker.com/r/obsrvbl](https://hub.docker.com/r/obsrvbl) organization's Docker image for packaging. The Dockerfiles are [public](https://github.com/obsrvbl/docker-images), so you don't have to trust @bbayles so much.
