### PR TITLE
Update to OSSEC 2.9.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX = /opt/obsrvbl-ossec
 TARGET = local
-VERSION = 2.9.2
+VERSION = 2.9.3
 BUILD_DIR = ossec-hids-${TARGET}
 TARGET_ROOT = ${BUILD_DIR}/target_root
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX = /opt/obsrvbl-ossec
 TARGET = local
-VERSION = 2.9.3
+VERSION = 2.9.4
 BUILD_DIR = ossec-hids-${TARGET}
 TARGET_ROOT = ${BUILD_DIR}/target_root
 


### PR DESCRIPTION
This PR updates ossec-hids to 2.9.4. - see the [release notes](https://github.com/ossec/ossec-hids/blob/v2.9.4/CHANGELOG#L6-L20).