### PR TITLE
Update to OSSEC 3.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX = /opt/obsrvbl-ossec
 TARGET = local
-VERSION = 2.9.2
+VERSION = 2.9.3
 BUILD_DIR = ossec-hids-${TARGET}
 TARGET_ROOT = ${BUILD_DIR}/target_root
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX = /opt/obsrvbl-ossec
 TARGET = local
-VERSION = 2.9.3
+VERSION = 2.9.4
 BUILD_DIR = ossec-hids-${TARGET}
 TARGET_ROOT = ${BUILD_DIR}/target_root
 


### PR DESCRIPTION
This PR updates ossec-hids to 3.0.0 - see the [release notes](https://github.com/ossec/ossec-hids/blob/v3.0.0/CHANGELOG#L10).